### PR TITLE
Feature/jsdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
+# JSDoc directory used for documentation
+jsdoc
+
 # node-waf configuration
 .lock-wscript
 

--- a/.jsdocconf
+++ b/.jsdocconf
@@ -1,0 +1,22 @@
+{
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc", "closure"]
+    },
+    "source": {
+        "include": ["./"],
+        "exclude": ["node_modules", "coverage", "tests"],
+        "includePattern": ".+\\.js(doc)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "plugins": [],
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    },
+    "opts": {
+        "destination": "./jsdoc",
+        "readme": "README.md",
+        "recurse": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ notifications:
     on_start: never
 after_script: 
       - "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
-      - "rm -rf ./jsdoc && npm run jsdoc"
+      - "npm run jsdoc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+after_script: 
+      - "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+      - "rm -rf ./jsdoc && npm run jsdoc"

--- a/README.md
+++ b/README.md
@@ -123,9 +123,7 @@ To see the logs only from the router implementation set the value of DEBUG to ex
 
 This section contains additional information about the development environment.
 
-### Container Parameters
-
-#### Environment Variables
+### Environment Variables
 
 * `LOGGER_LEVEL` - Set the logging level
   * Examples:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ For more in-depth testing, use a web debugging tool such as [Fiddler](https://ww
 
 ### API Route Documentation - [Swagger](http://swagger.io/)
 
-Once running locally, you can acceess swagger by going to: [http://localhost:3000/api-docs/](http://localhost:3000/api-docs/)
+Once running locally, you can access Swagger by going to: [http://localhost:3000/api-docs/swagger/](http://localhost:3000/api-docs/swagger/)
+
+### API JSDoc Documentation - [JSDoc](http://usejsdoc.org/)
+
+Once running locally, you can access JSDoc by going to: [http://localhost:3000/api-docs/](http://localhost:3000/api-docs/)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ For more in-depth testing, use a web debugging tool such as [Fiddler](https://ww
 
 [Postman collection](https://www.getpostman.com/collections/5530fbffa46505020891)
 
-### API Route Documentation - [Swagger](http://swagger.io/)
+### API Route Documentation
 
-Once running locally, you can access Swagger by going to: [http://localhost:3000/docs/api/](http://localhost:3000/docs/api/)
+Once running locally, you can access API route documentation (useful for those consuming the API) by going to: [http://localhost:3000/docs/api/](http://localhost:3000/docs/api/)
 
-### API JSDoc Documentation - [JSDoc](http://usejsdoc.org/)
+### API implementation Documentation
 
-Once running locally, you can access JSDoc by going to: [http://localhost:3000/docs/dev/](http://localhost:3000/docs/dev/)
+Once running locally, you can access API implementation documentation (useful for those implementing the API) by going to: [http://localhost:3000/docs/dev/](http://localhost:3000/docs/dev/)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ For more in-depth testing, use a web debugging tool such as [Fiddler](https://ww
 
 ### API Route Documentation - [Swagger](http://swagger.io/)
 
-Once running locally, you can access Swagger by going to: [http://localhost:3000/api-docs/swagger/](http://localhost:3000/api-docs/swagger/)
+Once running locally, you can access Swagger by going to: [http://localhost:3000/docs/api/](http://localhost:3000/docs/api/)
 
 ### API JSDoc Documentation - [JSDoc](http://usejsdoc.org/)
 
-Once running locally, you can access JSDoc by going to: [http://localhost:3000/api-docs/](http://localhost:3000/api-docs/)
+Once running locally, you can access JSDoc by going to: [http://localhost:3000/docs/dev/](http://localhost:3000/docs/dev/)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Note that this will lint the code before running tests. No tests will run if lin
 npm test
 ```
 
+### Generate API JSDoc documentation - [JSDoc](http://usejsdoc.org/)
+
+```bash
+npm run jsdoc
+```
+
 ### Start the API app
 
 To start the API with all debug logging enabled (recommended):

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "description": "Node.js + Express implementation of the RESTful AutoRenter API.",
   "main": "server/index.js",
   "scripts": {
-    "jsdoc": "jsdoc --configure .jsdocconf",
-    "prestart": "rm -rf ./jsdoc && npm run jsdoc",
+    "jsdoc": "rm -rf ./jsdoc && jsdoc --configure .jsdocconf",
+    "prestart": "npm run jsdoc",
     "start": "nodemon server --ignore \"tests/**/*.js\"",
     "lint": "eslint \"server/**/*.js\" \"tests/**/*.js\"",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha -- \"tests/**/*.js\" -R spec"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "description": "Node.js + Express implementation of the RESTful AutoRenter API.",
   "main": "server/index.js",
   "scripts": {
-    "jsdoc": "jsdoc --configure .jsdocconf",    
+    "jsdoc": "jsdoc --configure .jsdocconf",
+    "prestart": "npm run jsdoc",
     "start": "nodemon server --ignore \"tests/**/*.js\"",
     "lint": "eslint \"server/**/*.js\" \"tests/**/*.js\"",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha -- \"tests/**/*.js\" -R spec"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "main": "server/index.js",
   "scripts": {
     "jsdoc": "rm -rf ./jsdoc && jsdoc --configure .jsdocconf",
-    "prestart": "npm run jsdoc",
     "start": "nodemon server --ignore \"tests/**/*.js\"",
     "lint": "eslint \"server/**/*.js\" \"tests/**/*.js\"",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha -- \"tests/**/*.js\" -R spec"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "server/index.js",
   "scripts": {
     "jsdoc": "jsdoc --configure .jsdocconf",
-    "prestart": "npm run jsdoc",
+    "prestart": "rm -rf ./jsdoc && npm run jsdoc",
     "start": "nodemon server --ignore \"tests/**/*.js\"",
     "lint": "eslint \"server/**/*.js\" \"tests/**/*.js\"",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha -- \"tests/**/*.js\" -R spec"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "Node.js + Express implementation of the RESTful AutoRenter API.",
   "main": "server/index.js",
   "scripts": {
+    "jsdoc": "jsdoc --configure .jsdocconf",    
     "start": "nodemon server --ignore \"tests/**/*.js\"",
     "lint": "eslint \"server/**/*.js\" \"tests/**/*.js\"",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha -- \"tests/**/*.js\" -R spec"
@@ -28,8 +29,9 @@
     "git-rev": "0.2.1",
     "morgan": "1.8.0",
     "nodemon": "1.11.0",
-    "swagger-ui-express": "1.0.4",
+    "jsdoc": "3.4.3",
     "swagger-jsdoc": "1.9.1",
+    "swagger-ui-express": "1.0.4",
     "uuid": "3.0.1",
     "winston": "2.3.1"
   },

--- a/server/app.js
+++ b/server/app.js
@@ -46,8 +46,8 @@ app.get('/swagger.json', function(request, response) {
   response.json(swaggerSpec);
 });
 
-app.use('/api-docs/swagger', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-app.use('/api-docs', express.static('jsdoc/'));
+app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use('/docs/dev', express.static('jsdoc/'));
 app.use(apiPrefix, routes);
 
 // Note: this must go LAST, after the other handlers/routes have been configured.

--- a/server/app.js
+++ b/server/app.js
@@ -46,7 +46,8 @@ app.get('/swagger.json', function(request, response) {
   response.json(swaggerSpec);
 });
 
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use('/api-docs/swagger', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use('/api-docs', express.static('jsdoc/'));
 app.use(apiPrefix, routes);
 
 // Note: this must go LAST, after the other handlers/routes have been configured.

--- a/server/routes/locations/index.js
+++ b/server/routes/locations/index.js
@@ -26,7 +26,6 @@ module.exports = router;
  */
 
 /**
- * Get all locations route
  * @swagger
  * /locations:
  *   get:

--- a/server/routes/locations/index.js
+++ b/server/routes/locations/index.js
@@ -23,6 +23,7 @@ module.exports = router;
  */
 
 /**
+ * Get all locations route
  * @swagger
  * /locations:
  *   get:

--- a/server/services/locationServiceFactory.js
+++ b/server/services/locationServiceFactory.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * Location Service Factory
+ * @module services/locationServiceFactory
+ */
 const uuid = require('uuid/v4');
 const errorTypes = require('../models/errorTypes');
 
@@ -28,6 +32,11 @@ function build() {
       });
   }
 
+  /**
+  * @function addLocation
+  * @param  {Object} location - An AutoRenter location
+  * @return {Promise<{}>} - returns a location
+  */
   function addLocation(location) {
     return new Promise(
       (resolve) => {

--- a/server/services/locationServiceFactory.js
+++ b/server/services/locationServiceFactory.js
@@ -7,6 +7,9 @@
 const uuid = require('uuid/v4');
 const errorTypes = require('../models/errorTypes');
 
+/**
+ * @function build
+ */
 function build() {
   const locations = [
     {
@@ -25,6 +28,10 @@ function build() {
     }
   ];
 
+  /**
+   * @function getLocation
+   * @return {Promise<{}>} - returns a location
+   */
   function getLocations() {
     return new Promise(
       (resolve) => {
@@ -35,7 +42,7 @@ function build() {
   /**
   * @function addLocation
   * @param  {Object} location - An AutoRenter location
-  * @return {Promise<{}>} - returns a location
+  * @return {Promise.<{}>} - returns a location
   */
   function addLocation(location) {
     return new Promise(
@@ -47,6 +54,11 @@ function build() {
     );
   }
 
+  /**
+  * @function getLocation
+  * @param  {string} locationId - The id of the location to return
+  * @return {Promise.<{}>} - returns a location
+  */
   function getLocation(locationId) {
     return new Promise(
       (resolve, reject) => {
@@ -67,6 +79,11 @@ function build() {
     );
   }
 
+  /**
+  * @function updateLocation
+  * @param  {Object} location - The location to update
+  * @return {Promise.<{}>} - returns the updated location
+  */
   function updateLocation(location) {
     return new Promise(
       (resolve, reject) => {
@@ -83,6 +100,11 @@ function build() {
     );
   }
 
+  /**
+  * @function deleteLocation
+  * @param  {string} locationId - The id of the location to be deleted
+  * @return {Promise.<{}>}
+  */
   function deleteLocation(locationId) {
     return new Promise(
       (resolve, reject) => {

--- a/server/services/locationServiceFactory.js
+++ b/server/services/locationServiceFactory.js
@@ -9,6 +9,7 @@ const errorTypes = require('../models/errorTypes');
 
 /**
  * @function build
+ * @return {array} - The factory methods
  */
 function build() {
   const locations = [
@@ -30,7 +31,7 @@ function build() {
 
   /**
    * @function getLocation
-   * @return {Promise<{}>} - returns a location
+   * @return {Promise<{}>} - @resolve returns a location
    */
   function getLocations() {
     return new Promise(
@@ -42,7 +43,7 @@ function build() {
   /**
   * @function addLocation
   * @param  {Object} location - An AutoRenter location
-  * @return {Promise.<{}>} - returns a location
+  * @return {Promise.<{}>} - @resolve returns a location
   */
   function addLocation(location) {
     return new Promise(
@@ -57,7 +58,9 @@ function build() {
   /**
   * @function getLocation
   * @param  {string} locationId - The id of the location to return
-  * @return {Promise.<{}>} - returns a location
+  * @return {Promise.<{}>}
+      - @resolve returns a location<br/>
+      - @reject returns an error message if no location was found with the provided id
   */
   function getLocation(locationId) {
     return new Promise(
@@ -82,7 +85,9 @@ function build() {
   /**
   * @function updateLocation
   * @param  {Object} location - The location to update
-  * @return {Promise.<{}>} - returns the updated location
+  * @return {Promise.<{}>}
+      - @resolve returns the updated location<br/>
+      - @reject returns an error
   */
   function updateLocation(location) {
     return new Promise(
@@ -104,6 +109,7 @@ function build() {
   * @function deleteLocation
   * @param  {string} locationId - The id of the location to be deleted
   * @return {Promise.<{}>}
+      - @reject returns an error
   */
   function deleteLocation(locationId) {
     return new Promise(

--- a/server/services/logDetail.js
+++ b/server/services/logDetail.js
@@ -23,8 +23,6 @@ function logDetail(username, level, message) {
   /**
   * @constant
   * @type {Promise.<{}>}
-      - @resolve Sets the debug message and writes to the logger.<br/>
-      - @reject Returns an error message if the log message was empty.
   * @default
   */
   const log = new Promise((resolve, reject) => {

--- a/server/services/logDetail.js
+++ b/server/services/logDetail.js
@@ -13,10 +13,20 @@ const logger = require('./logger');
 * @param  {string} username - The user creating the log entry
 * @param  {string} level    - The level of the log entry
 * @param  {string} message  - The message of the log entry
-* @return {Promise.<{}>} - Returns 'Log added' on success or an error message with details on failure.
+* @return {Promise.<{}>}
+    - @resolve Writes the debug message 'Log added' to the logger.<br/>
+    - @reject Returns an error message if the log message was empty.<br/>
+    - @reject Returns an error message with details if the data could not be logged.
 */
 function logDetail(username, level, message) {
   const logData = {username, level, message};
+  /**
+  * @constant
+  * @type {Promise.<{}>}
+      - @resolve Sets the debug message and writes to the logger.<br/>
+      - @reject Returns an error message if the log message was empty.
+  * @default
+  */
   const log = new Promise((resolve, reject) => {
     if(!logData.message) {
       const err = new Error('Log message was empty');

--- a/server/services/logDetail.js
+++ b/server/services/logDetail.js
@@ -1,8 +1,20 @@
 'use strict';
 
+/**
+ * Log Detail Service
+ * @module services/logDetail
+ */
+
 const errorTypes = require('../models/errorTypes');
 const logger = require('./logger');
 
+/**
+* @function logDetail
+* @param  {string} username - The user creating the log entry
+* @param  {string} level    - The level of the log entry
+* @param  {string} message  - The message of the log entry
+* @return {Promise.<{}>} - Returns 'Log added' on success or an error message with details on failure.
+*/
 function logDetail(username, level, message) {
   const logData = {username, level, message};
   const log = new Promise((resolve, reject) => {

--- a/server/services/lookupDataServiceFactory.js
+++ b/server/services/lookupDataServiceFactory.js
@@ -7,6 +7,10 @@
 
 const errorTypes = require('../models/errorTypes');
 
+/**
+* @function build
+* @return {build~getData} - The getData function
+*/
 function build() {
   let lookupData = {};
   lookupData.states = [

--- a/server/services/lookupDataServiceFactory.js
+++ b/server/services/lookupDataServiceFactory.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * Lookup Data Service
+ * @module services/lookupDataService
+ */
+
 const errorTypes = require('../models/errorTypes');
 
 function build() {
@@ -63,6 +68,14 @@ function build() {
     },
   ];
 
+  /**
+  * @function getData
+  * @param  {string} lookupTypes - This is a query string which specifies which types of data to fetch.
+  * @return {Promise<{}>}
+      - @resolve Returns lookupData object with the requested data.<br/>
+      - @reject Returns an error message if no types were specified.<br/>
+      - @reject Returns an error message if the provided type does not exist.
+  */
   function getData(lookupTypes) {
     return new Promise(
       (resolve, reject) => {


### PR DESCRIPTION
NOTES: 
* This branch needs additional documentation, but it contains the initial setup for jsdoc.
* The official JSDoc spec does not yet support ES6 Promises.  More detail can be found here: https://github.com/jsdoc3/jsdoc/issues/1197  Apparently the decision about the syntax has been made (as of 11/2015), but not yet implemented (as of 2/2017).
* I added a prestart command to the package.json file to generate the jsdoc UI and statically defined the route to it in app.js.  I'd like to modify this so that it works with the existing hot-reloading setup.  Currently the UI is not regenerated automatically when changes are made to files; one must manually stop/start the api.
* Because JSDoc incorporates the readme file into it's UI, I used /api-docs/ as the route for JSDoc and modified the Swagger route to be /api-docs/swagger, a link to which can be found in the readme.
* The UI is useable, but the templates should be reviewed by someone from the Digital team to bring them in line with proper Fusion branding/layouts.