### PR TITLE
feature/jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "server/index.js",
   "scripts": {
     "jsdoc": "rm -rf ./jsdoc && jsdoc --configure .jsdocconf",
+    "prestart": "npm run jsdoc",
     "start": "nodemon server --ignore \"tests/**/*.js\"",
     "lint": "eslint \"server/**/*.js\" \"tests/**/*.js\"",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha -- \"tests/**/*.js\" -R spec"


### PR DESCRIPTION
Re-added prestart b/c jsdoc wasn't available in heroku build.