### PR TITLE
SwaggerUI validation error after Heroku deployment

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -7,7 +7,6 @@ const swaggerJSDoc = require('swagger-jsdoc');
 const config = require('./config');
 
 const app = module.exports = express();
-const env = app.get('env');
 const configureLogger = require('./middleware/configureLogger');
 const configureBodyParser = require('./middleware/configureBodyParser');
 const configureCors = require('./middleware/configureCors');
@@ -47,7 +46,7 @@ app.get('/swagger.json', function(request, response) {
 });
 
 const options = {
-  validatorUrl: env === 'production' ? 'https://autorenter-nodeexpress-api.herokuapp.com/swagger.json' : null //eslint-disable-line
+  validatorUrl: config.server.environment === 'production' ? 'https://autorenter-nodeexpress-api.herokuapp.com/swagger.json' : null //eslint-disable-line
 };
 
 app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(swaggerSpec, true, options));

--- a/server/app.js
+++ b/server/app.js
@@ -46,7 +46,11 @@ app.get('/swagger.json', function(request, response) {
   response.json(swaggerSpec);
 });
 
-app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+const options = {
+  validatorUrl: './swagger.json'
+};
+
+app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(swaggerSpec, true, options));
 app.use('/docs/dev', express.static('jsdoc/'));
 app.use(apiPrefix, routes);
 

--- a/server/app.js
+++ b/server/app.js
@@ -7,7 +7,7 @@ const swaggerJSDoc = require('swagger-jsdoc');
 const config = require('./config');
 
 const app = module.exports = express();
-
+const env = app.get('env');
 const configureLogger = require('./middleware/configureLogger');
 const configureBodyParser = require('./middleware/configureBodyParser');
 const configureCors = require('./middleware/configureCors');
@@ -47,7 +47,7 @@ app.get('/swagger.json', function(request, response) {
 });
 
 const options = {
-  validatorUrl: './swagger.json'
+  validatorUrl: env === 'production' ? 'https://autorenter-nodeexpress-api.herokuapp.com/swagger.json' : null //eslint-disable-line
 };
 
 app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(swaggerSpec, true, options));

--- a/server/config.js
+++ b/server/config.js
@@ -6,6 +6,7 @@ config.server = {
   host: process.env.HOST || '0.0.0.0',
   port: process.env.PORT || 3000,
   loggerLevel: process.env.LOGGER_LEVEL || 'debug',
+  environment: process.env.NODE_ENV || 'development',
   title: process.env.npm_package_name,
   version: process.env.npm_package_version,
   description: process.env.npm_package_description


### PR DESCRIPTION
Added options to app.js to set the validation url in the swagger-ui-express package.